### PR TITLE
Docs: Adding Apache License verbiage to Go files.

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Allyn L. Bottorff
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package as3parse
 
 import (

--- a/functions_test.go
+++ b/functions_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Allyn L. Bottorff
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package as3parse
 
 import (
@@ -79,7 +93,6 @@ func TestParseDec(t *testing.T) {
 	}
 
 }
-
 
 func TestPrintDec(t *testing.T) {
 

--- a/types.go
+++ b/types.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Allyn L. Bottorff
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package as3parse
 
 import (


### PR DESCRIPTION
Closes #4 